### PR TITLE
Removes use of `child-software-process`

### DIFF
--- a/catalog/couchdb/couchdb-cluster.bom
+++ b/catalog/couchdb/couchdb-cluster.bom
@@ -95,7 +95,7 @@ brooklyn.catalog:
     iconUrl: *couchIconUrl
     item:
       services:
-      - type: child-software-process
+      - type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
         id: couch-coordination-node
         name: "CouchDB coordination node"
         brooklyn.config:


### PR DESCRIPTION
Use of this wrapper id `child-software-process`

`child-software-process` is `org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess` use this instead