### PR TITLE
Update packaging config to allow installation via brooklyn.libraries

### DIFF
--- a/catalog/catalog.bom
+++ b/catalog/catalog.bom
@@ -18,7 +18,7 @@
 #
 brooklyn.catalog:
   items:
-  - https://raw.githubusercontent.com/brooklyncentral/brooklyn-couchdb-cluster/master/catalog/couchdb/couchdb-cluster.bom
+  - classpath://couchdb/couchdb-cluster.bom
   - id: couchdb-cluster-template
     name: "CouchDB Cluster"
     version: 1.0.4-SNAPSHOT # BROOKLYN_COUCHDB_CLUSTER_VERSION


### PR DESCRIPTION
To install a bundle via a bom file and brooklyn.libraries, you need to have:

- a valid OSGi bundle (was already there)
- a `catalog.bom` at the root of the bundle, which this PR adds