### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/catalog/couchdb/couchdb-cluster.bom
+++ b/catalog/couchdb/couchdb-cluster.bom
@@ -155,7 +155,7 @@ brooklyn.catalog:
       name: "CouchDB setup coordination node"
       brooklyn.config:
         download.url:
-        install.latch: $brooklyn:parent().parent().attributeWhenReady("service.allNodesUp")
+        latch.install: $brooklyn:parent().parent().attributeWhenReady("service.allNodesUp")
         shell.env:
           HOSTNAMES: $brooklyn:parent().parent().attributeWhenReady("cluster.hostnames")
           HOST: $brooklyn:parent().attributeWhenReady("host.subnet.address")


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names.